### PR TITLE
docs(badges): add standard badges to README [PR-41]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<a href=https://engineering-metrics.typeform.tf/standards-adoption-tool/reports/statsd_exporter/><img src=https://api.typeform.com/repositories/statsd_exporter/badges.svg /></a>
 # statsd exporter [![Build Status](https://travis-ci.org/prometheus/statsd_exporter.svg)][travis]
 
 [![CircleCI](https://circleci.com/gh/prometheus/statsd_exporter/tree/master.svg?style=shield)][circleci]


### PR DESCRIPTION
Add new badges img to repository

[_Created by Sourcegraph batch change `engineering-intelligence/PR-41-update-repo-badges-img-no-previous-badge`._](https://sourcegraph.tools.typeform.tf/users/engineering-intelligence/batch-changes/PR-41-update-repo-badges-img-no-previous-badge)